### PR TITLE
Load emojicom widget only on post page(earlier it was loaded on every…

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -178,6 +178,10 @@ into the {body} of the default.hbs template --}}
 
 {{!-- The #contentFor helper here will send everything inside it up to the matching #block helper found in default.hbs --}}
 {{#contentFor "scripts"}}
+<!-- Start emojicom.io widget -->
+{{!-- Emojicom campaign ID is set in blog settings via injected code --}}
+<script src="https://cdn.emojicom.io/embed/widget.js" async></script>
+<!-- End emojicom.io widget -->
 <script>
     $(document).ready(function () {
         // FitVids - start


### PR DESCRIPTION
… page because of injected code setting and automatically attached to document.body if it couldn't find its container)